### PR TITLE
Feature/email

### DIFF
--- a/src/main/java/kori/tour/email/application/updater/EmailSendEventListener.java
+++ b/src/main/java/kori/tour/email/application/updater/EmailSendEventListener.java
@@ -7,7 +7,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
@@ -45,7 +44,7 @@ public class EmailSendEventListener {
 		Pageable pageable = PageRequest.of(0,500);
 		while (true) {
 			Slice<Member> memberPage = emailService.findMembersBySubscription(newTourDto.getTour().getAreaCode(), newTourDto.getTour().getSigunGuCode(), pageable);
-			for(List<Member> members : partition(memberPage.toList(), 50)){
+			for(List<Member> members : partition(memberPage.getContent(), 50)){
 				EmailSendRequestDto requestDto = mapToSendEmailRequestDto(members, emailTitle, emailBody, newTourDto.getTour());
 				String messageId = emailService.sendEmailToMembers(requestDto);
 				emailService.saveEmails(members, messageId, newTourDto.getTour(), emailTitle, emailBody);

--- a/src/main/java/kori/tour/email/application/updater/EmailService.java
+++ b/src/main/java/kori/tour/email/application/updater/EmailService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kori.tour.email.adapter.out.persistence.EmailRepository;
-import kori.tour.email.application.updater.dto.EmailSendRequestDto;
+import kori.tour.email.application.updater.dto.EmailSendRequest;
 import kori.tour.email.domain.Email;
 import kori.tour.member.adapter.out.persistence.MemberRepository;
 import kori.tour.member.domain.Member;
@@ -38,7 +38,7 @@ public class EmailService {
 	@Value("${email.sender}")
 	private String senderEmail;
 
-	public String sendEmailToMembers(EmailSendRequestDto requestDto) {
+	public String sendEmailToMembers(EmailSendRequest requestDto) {
 		List<String> emails = requestDto.members().stream()
 				.map(Member::getPlatformInfo)
 				.map(PlatformInfo::getPlatformEmail)
@@ -57,13 +57,7 @@ public class EmailService {
 
 		SendEmailResponse response = sesClient.sendEmail(request);
 
-		log.info("[EmailSendSuccess] 총 {}명의 회원에게 이메일 발송 완료 | Tour ID: {} | Message ID: {} | 지역 코드: {}-{}",
-				requestDto.members().size(),
-				requestDto.tourId(),
-				response.messageId(),
-				requestDto.areaCode(),
-				requestDto.sigunGuCode()
-		);
+		log.info("Email sent to {} with messageId {}", emails, response.messageId());
 
 		return response.messageId();
 	}

--- a/src/main/java/kori/tour/email/application/updater/EmailService.java
+++ b/src/main/java/kori/tour/email/application/updater/EmailService.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;

--- a/src/main/java/kori/tour/email/application/updater/EmailService.java
+++ b/src/main/java/kori/tour/email/application/updater/EmailService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,7 +68,7 @@ public class EmailService {
 	}
 
 	public List<Member> findMembersBySubscription(String areaCode, String sigunGucCode){
-		return memberRepository.findBySubscriptionArea(areaCode, sigunGucCode);
+		return memberRepository.findBySubscriptionArea(areaCode, sigunGucCode, PageRequest.of(10,0)).getContent();
 	}
 
 	@Transactional

--- a/src/main/java/kori/tour/email/application/updater/EmailService.java
+++ b/src/main/java/kori/tour/email/application/updater/EmailService.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,8 +69,8 @@ public class EmailService {
 		return response.messageId();
 	}
 
-	public List<Member> findMembersBySubscription(String areaCode, String sigunGucCode){
-		return memberRepository.findBySubscriptionArea(areaCode, sigunGucCode, PageRequest.of(10,0)).getContent();
+	public Slice<Member> findMembersBySubscription(String areaCode, String sigunGucCode, Pageable pageRequest){
+		return memberRepository.findBySubscriptionArea(areaCode, sigunGucCode, pageRequest);
 	}
 
 	@Transactional

--- a/src/main/java/kori/tour/email/application/updater/dto/EmailSendRequest.java
+++ b/src/main/java/kori/tour/email/application/updater/dto/EmailSendRequest.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import kori.tour.member.domain.Member;
 
-public record EmailSendRequestDto(
+public record EmailSendRequest(
         List<Member> members,
         String emailTitle,
         String emailContent,

--- a/src/main/java/kori/tour/member/adapter/out/persistence/MemberRepository.java
+++ b/src/main/java/kori/tour/member/adapter/out/persistence/MemberRepository.java
@@ -1,6 +1,6 @@
 package kori.tour.member.adapter.out.persistence;
 
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +10,7 @@ import kori.tour.member.domain.Member;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	@Query("SELECT m FROM Member m JOIN m.subscriptions.subscriptions s "
-			+ "WHERE s.areaCode = :areaCode AND s.sigunGuCode = :sigunGuCode")
-	Slice<Member> findBySubscriptionArea(String areaCode, String sigunGuCode, PageRequest pageRequest);
+			+ "WHERE s.areaCode = :areaCode AND s.sigunGuCode = :sigunGuCode order by m.id")
+	Slice<Member> findBySubscriptionArea(String areaCode, String sigunGuCode, Pageable pageRequest);
 
 }

--- a/src/main/java/kori/tour/member/adapter/out/persistence/MemberRepository.java
+++ b/src/main/java/kori/tour/member/adapter/out/persistence/MemberRepository.java
@@ -1,7 +1,7 @@
 package kori.tour.member.adapter.out.persistence;
 
-import java.util.List;
-
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,6 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	@Query("SELECT m FROM Member m JOIN m.subscriptions.subscriptions s "
 			+ "WHERE s.areaCode = :areaCode AND s.sigunGuCode = :sigunGuCode")
-	List<Member> findBySubscriptionArea(String areaCode, String sigunGuCode);
+	Slice<Member> findBySubscriptionArea(String areaCode, String sigunGuCode, PageRequest pageRequest);
 
 }

--- a/src/main/java/kori/tour/member/domain/Member.java
+++ b/src/main/java/kori/tour/member/domain/Member.java
@@ -1,14 +1,14 @@
 package kori.tour.member.domain;
-
-
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.Set;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(builderMethodName = "internalBuilder")
 public class Member {
 
 	@Id
@@ -25,6 +25,25 @@ public class Member {
 	@Embedded
 	private Subscriptions subscriptions = new Subscriptions();
 
-	// Todo 비즈니스 로직은 데이터 흐름을 파악하고 작성하도록하자
+	public static MemberBuilder builder() {
+		return internalBuilder().subscriptions(new Subscriptions());
+	}
+
+	public Set<Subscription> getSubscriptions() {
+		return subscriptions.getSubscriptions();
+	}
+
+	/**
+	 * 중복 Subscription, null 체크 -> 유일성이 깨진 경우에 서비스 계층으로
+	 * 예외를 던지는 로직을 고려해봤는데, 결국은 크게 의미가 없는 것 같아.
+	 * 프론트에서 순간적으로 꼬이거나, API의 엔드포인트를 알지 않는 이상 발생 x
+	 * */
+	public void addSubscription(Subscription subscription) {
+		this.subscriptions.add(subscription);
+	}
+
+	public void removeSubscription(Subscription subscription) {
+		this.subscriptions.remove(subscription);
+	}
 
 }

--- a/src/main/java/kori/tour/member/domain/Member.java
+++ b/src/main/java/kori/tour/member/domain/Member.java
@@ -1,8 +1,8 @@
 package kori.tour.member.domain;
+import java.util.Set;
+
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.util.Set;
 
 @Entity
 @Getter

--- a/src/main/java/kori/tour/member/domain/Subscription.java
+++ b/src/main/java/kori/tour/member/domain/Subscription.java
@@ -3,12 +3,12 @@ package kori.tour.member.domain;
 import java.util.Objects;
 
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Embeddable
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Subscription {
 
@@ -17,8 +17,6 @@ public class Subscription {
 	private String sigunGuCode;
 
 	private String sigunGuName;
-
-	//Todo maybe need all-Args-Constructor
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/kori/tour/member/domain/Subscriptions.java
+++ b/src/main/java/kori/tour/member/domain/Subscriptions.java
@@ -4,10 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.JoinColumn;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -18,11 +15,21 @@ public class Subscriptions {
     @ElementCollection
     @CollectionTable(
             name = "member_subscription",
-            joinColumns = @JoinColumn(name = "member_id"))
+            joinColumns = @JoinColumn(name = "member_id"),
+            uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "area_code", "sigun_gu_code"}),
+            indexes = @Index(name = "idx_region", columnList = "area_code, sigun_gu_code"))
     private Set<Subscription> subscriptions = new HashSet<>();
 
     public Set<Subscription> getSubscriptions() {
         return Collections.unmodifiableSet(subscriptions);
+    }
+
+    public void add(Subscription subscription) {
+        this.subscriptions.add(subscription);
+    }
+
+    public void remove(Subscription subscription) {
+        this.subscriptions.remove(subscription);
     }
 
 }

--- a/src/test/java/kori/tour/email/application/updater/EmailServiceTest.java
+++ b/src/test/java/kori/tour/email/application/updater/EmailServiceTest.java
@@ -13,7 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import kori.tour.email.adapter.out.persistence.EmailRepository;
-import kori.tour.email.application.updater.dto.EmailSendRequestDto;
+import kori.tour.email.application.updater.dto.EmailSendRequest;
 import kori.tour.member.adapter.out.persistence.MemberRepository;
 import kori.tour.member.domain.Member;
 import kori.tour.member.domain.PlatformInfo;
@@ -55,7 +55,7 @@ class EmailServiceTest {
                 .sigunGuCode("10")
                 .build();
 
-        EmailSendRequestDto requestDto = new EmailSendRequestDto(
+        EmailSendRequest requestDto = new EmailSendRequest(
                 List.of(member),
                 "테스트 제목",
                 "테스트 내용",

--- a/src/test/java/kori/tour/member/adapter/out/persistence/MemberRepositoryTest.java
+++ b/src/test/java/kori/tour/member/adapter/out/persistence/MemberRepositoryTest.java
@@ -2,6 +2,7 @@ package kori.tour.member.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Comparator;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -13,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 
 import kori.tour.member.domain.Member;
 import kori.tour.member.domain.Subscription;
@@ -59,7 +59,7 @@ class MemberRepositoryTest {
     @DisplayName("특정 지역을 구독하는 회원을 페이지네이션하여 첫 페이지를 조회한다")
     void findBySubscriptionArea_shouldReturnFirstPageOfSubscribedMembers() {
         // given
-        PageRequest pageRequest = PageRequest.of(0, 3, Sort.by(Sort.Direction.ASC, "id"));
+        PageRequest pageRequest = PageRequest.of(0, 3);
 
         // when
         Slice<Member> result = memberRepository.findBySubscriptionArea(TARGET_AREA_CODE, TARGET_SIGUNGU_CODE, pageRequest);
@@ -69,18 +69,14 @@ class MemberRepositoryTest {
         assertThat(result.getNumber()).isEqualTo(0);
         assertThat(result.hasNext()).isTrue();
         assertThat(result.isFirst()).isTrue();
-        result.getContent().forEach(member ->
-            assertThat(member.getSubscriptions()).anyMatch(s ->
-                    s.getAreaCode().equals(TARGET_AREA_CODE) && s.getSigunGuCode().equals(TARGET_SIGUNGU_CODE)
-            )
-        );
+        assertThat(result.getContent()).isSortedAccordingTo(Comparator.comparing(Member::getId));
     }
 
     @Test
     @DisplayName("특정 지역을 구독하는 회원을 페이지네이션하여 마지막 페이지를 조회한다")
     void findBySubscriptionArea_shouldReturnLastPageOfSubscribedMembers() {
         // given
-        PageRequest pageRequest = PageRequest.of(1, 3, Sort.by(Sort.Direction.ASC, "id"));
+        PageRequest pageRequest = PageRequest.of(1, 3);
 
         // when
         Slice<Member> result = memberRepository.findBySubscriptionArea(TARGET_AREA_CODE, TARGET_SIGUNGU_CODE, pageRequest);
@@ -90,11 +86,7 @@ class MemberRepositoryTest {
         assertThat(result.getNumber()).isEqualTo(1);
         assertThat(result.hasNext()).isFalse();
         assertThat(result.isLast()).isTrue();
-        result.getContent().forEach(member ->
-            assertThat(member.getSubscriptions()).anyMatch(s ->
-                    s.getAreaCode().equals(TARGET_AREA_CODE) && s.getSigunGuCode().equals(TARGET_SIGUNGU_CODE)
-            )
-        );
+        assertThat(result.getContent()).isSortedAccordingTo(Comparator.comparing(Member::getId));
     }
 
     @Test

--- a/src/test/java/kori/tour/member/adapter/out/persistence/MemberRepositoryTest.java
+++ b/src/test/java/kori/tour/member/adapter/out/persistence/MemberRepositoryTest.java
@@ -1,0 +1,115 @@
+package kori.tour.member.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+
+import kori.tour.member.domain.Member;
+import kori.tour.member.domain.Subscription;
+
+@DataJpaTest
+class MemberRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private final String TARGET_AREA_CODE = "1";
+    private final String TARGET_SIGUNGU_CODE = "10";
+
+    @BeforeEach
+    void setUp() {
+        Subscription targetSubscription = Subscription.builder()
+                .areaCode(TARGET_AREA_CODE)
+                .sigunGuCode(TARGET_SIGUNGU_CODE)
+                .sigunGuName("테스트시군구")
+                .build();
+
+        Subscription otherSubscription = Subscription.builder()
+                .areaCode("2")
+                .sigunGuCode("20")
+                .sigunGuName("다른시군구")
+                .build();
+        // 5명의 회원을 생성하여 지역을 두개씩 구독
+        IntStream.range(0, 5).forEach(i -> {
+            Member member = Member.builder().build();
+            member.addSubscription(targetSubscription);
+            member.addSubscription(otherSubscription);
+            memberRepository.save(member);
+        });
+
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("특정 지역을 구독하는 회원을 페이지네이션하여 첫 페이지를 조회한다")
+    void findBySubscriptionArea_shouldReturnFirstPageOfSubscribedMembers() {
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 3, Sort.by(Sort.Direction.ASC, "id"));
+
+        // when
+        Slice<Member> result = memberRepository.findBySubscriptionArea(TARGET_AREA_CODE, TARGET_SIGUNGU_CODE, pageRequest);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getNumber()).isEqualTo(0);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.isFirst()).isTrue();
+        result.getContent().forEach(member ->
+            assertThat(member.getSubscriptions()).anyMatch(s ->
+                    s.getAreaCode().equals(TARGET_AREA_CODE) && s.getSigunGuCode().equals(TARGET_SIGUNGU_CODE)
+            )
+        );
+    }
+
+    @Test
+    @DisplayName("특정 지역을 구독하는 회원을 페이지네이션하여 마지막 페이지를 조회한다")
+    void findBySubscriptionArea_shouldReturnLastPageOfSubscribedMembers() {
+        // given
+        PageRequest pageRequest = PageRequest.of(1, 3, Sort.by(Sort.Direction.ASC, "id"));
+
+        // when
+        Slice<Member> result = memberRepository.findBySubscriptionArea(TARGET_AREA_CODE, TARGET_SIGUNGU_CODE, pageRequest);
+
+        // then
+        assertThat(result.getContent()).hasSize(2); // 5명 중 2번째 페이지 (크기: 3) -> 2명
+        assertThat(result.getNumber()).isEqualTo(1);
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.isLast()).isTrue();
+        result.getContent().forEach(member ->
+            assertThat(member.getSubscriptions()).anyMatch(s ->
+                    s.getAreaCode().equals(TARGET_AREA_CODE) && s.getSigunGuCode().equals(TARGET_SIGUNGU_CODE)
+            )
+        );
+    }
+
+    @Test
+    @DisplayName("구독자가 없는 지역을 조회하면 빈 Slice를 반환한다")
+    void findBySubscriptionArea_shouldReturnEmptySliceForUnsubscribedArea() {
+        // given
+        PageRequest pageRequest = PageRequest.of(0, 3);
+        String nonExistentAreaCode = "99";
+        String nonExistentSigunguCode = "999";
+
+        // when
+        Slice<Member> result = memberRepository.findBySubscriptionArea(nonExistentAreaCode, nonExistentSigunguCode, pageRequest);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.hasNext()).isFalse();
+    }
+}

--- a/src/test/java/kori/tour/member/domain/MemberTest.java
+++ b/src/test/java/kori/tour/member/domain/MemberTest.java
@@ -1,0 +1,48 @@
+package kori.tour.member.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MemberTest {
+
+    @Test
+    @DisplayName("새로운 구독이 정상적으로 추가된다")
+    void addSubscription_shouldAddNewSubscription() {
+        //given
+        Member member = Member.builder().build();
+        Subscription subscription = Subscription.builder().build();
+
+        //when
+        member.addSubscription(subscription);
+
+        //then
+        Set<Subscription> subscriptions = member.getSubscriptions();
+        assertThat(subscriptions).contains(subscription);
+    }
+
+    @Test
+    @DisplayName("중복된 구독은 여러 번 추가되지 않고 1개만 유지된다")
+    void addSubscription_shouldNotAddDuplicateSubscription() {
+        //given
+        Member member = Member.builder().build();
+        Subscription subscription = Subscription.builder().build();
+
+        //when
+        member.addSubscription(subscription);
+        member.addSubscription(subscription);
+
+        //then
+        Set<Subscription> subscriptions = member.getSubscriptions();
+        assertThat(subscriptions).hasSize(1).containsExactly(subscription);
+    }
+
+    @Test
+    @DisplayName("null 구독을 추가하려 하면 예외가 발생한다")
+    void addSubscription_shouldHandleNullSubscriptionGracefully() {
+        // 별로 의미 없는 케이스라서 테스트에서 제외
+    }
+}

--- a/src/test/java/kori/tour/member/domain/MemberTest.java
+++ b/src/test/java/kori/tour/member/domain/MemberTest.java
@@ -1,11 +1,11 @@
 package kori.tour.member.domain;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
 
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 class MemberTest {
 


### PR DESCRIPTION
### 주요 작업 설명

#12 에서 언급한대로 특정 지역을 구독한 회원을 조회할 때, 페이징 기능을 도입했습니다.

**진행한 작업**
1. DB에서 조회할때 페이지 사이즈: 500 ( Member 객체의 사이즈 고려 )
2. SES에 조회할 때 페이지 사이즈: 50 ( SES 스펙에 맞춤 )
3. member_subscription 테이블에 유니크 제약조건, 인덱스 추가 
4. MemberRepository 쿼리를 페이징 쿼리로 수정 
    - order by로 정렬 ( 유니크 인덱스, PK 인덱스가 있어서 RDBMS에서 정렬을 위한 추가적인 부하가 크지 않음 )
    - 그리고, 페이징을 할때 순서의 안정성을 보장하기위해 정렬하는게 낫다고한다

**이어서 개선 해야할 작업들**
1.  EmailSendEventListener 클래스의 listenEmailSendEvent 메소드 내부 로직 (while 문) 
2. While 문으로 인해 계속 조회되는 Member 객체가 영속성 컨텍스트에 누적되는지 즉시 제거되는지 판단해야한다

```java
		while (true) {
			Slice<Member> memberPage = emailService.findMembersBySubscription(newTourDto.getTour().getAreaCode(), newTourDto.getTour().getSigunGuCode(), pageable);
			for(List<Member> members : partition(memberPage.getContent(), SES_PAGE_SIZE)){
				EmailSendRequest emailSendRequest = mapToSendEmailRequestDto(members, emailTitle, emailBody, newTourDto.getTour());
				String messageId = emailService.sendEmailToMembers(emailSendRequest);
				emailService.saveEmails(members, messageId, newTourDto.getTour(), emailTitle, emailBody);
				emailSendMessageIdList.add(messageId);
				totalMemberCount +=members.size();
			}
			if (!memberPage.hasNext()) break;
			pageable = memberPage.nextPageable();
		}
``` 
-> **분석 결과**: 영속성 컨텍스트에 누적되지 않는다 ! 
findMembersBySubscription 메소드에서 조회해 온 후, members는 detach 상태로 들어간다. 
이후에, saveEmails로직을 보면, members, tour를 다시 영속성 컨텍스트에 넣는걸 바탕으로 이를 다시 이해할수있음.

영속성 컨텍스트의 범위가 헷갈릴때면 트랜잭션을 항상 고려하자!




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved subscription handling with reliable add/remove behavior.

* **Refactor**
  * Paginated, batched email dispatch with per-batch processing and summary logging for more scalable, resilient deliveries.

* **Chores**
  * Enforced uniqueness and added indexing for subscription data to prevent duplicates and speed lookups.

* **Tests**
  * Added tests for paginated subscriber retrieval and subscription management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->