### PR TITLE
Email 테이블 마이그레이션 및 저장 용량 최소화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,9 @@ dependencies {
 
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+    //jsoup
+    implementation 'org.jsoup:jsoup:1.16.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/kori/tour/email/adapter/out/persistence/EmailContentRepository.java
+++ b/src/main/java/kori/tour/email/adapter/out/persistence/EmailContentRepository.java
@@ -1,0 +1,8 @@
+package kori.tour.email.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kori.tour.email.domain.EmailContent;
+
+public interface EmailContentRepository extends JpaRepository <EmailContent, Long>{
+}

--- a/src/main/java/kori/tour/email/application/updater/EmailContentParser.java
+++ b/src/main/java/kori/tour/email/application/updater/EmailContentParser.java
@@ -1,5 +1,8 @@
 package kori.tour.email.application.updater;
 
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
@@ -46,6 +49,23 @@ public class EmailContentParser {
 		context.setVariable("telephone", emailBodyDto.getTelephone());
 
 		return templateEngine.process("email-body", context);
+	}
+
+	/**
+	 * 실제 사용자에게 전송되는 이메일과 띄어쓰기 하나 정도 차이가 있음.
+	 * 여기에 시간을 더 쏟는 것 보다 빠르게 치고가는게 더 효율적이라서 일단 이 정도로만~
+	 * minify 전: 약 2100바이트 minify 후: 약 1800바이트 -> 약 300 바이트 감소
+	 * */
+	public String minifyHtml(String html){
+		Document doc = Jsoup.parse(html);
+		doc.outputSettings().prettyPrint(false);
+
+		Element body = doc.body();
+		String innerHtml = body.html();
+
+		innerHtml = innerHtml.replaceAll(">\\s+<", "><").trim();
+
+        return "<body>" + innerHtml + "</body>";
 	}
 
 }

--- a/src/main/java/kori/tour/email/application/updater/EmailSendUseCase.java
+++ b/src/main/java/kori/tour/email/application/updater/EmailSendUseCase.java
@@ -1,8 +1,0 @@
-package kori.tour.email.application.updater;
-
-import java.util.List;
-
-public interface EmailSendUseCase {
-
-    String sendEmail(List<String> recipients, String title, String content);
-}

--- a/src/main/java/kori/tour/email/application/updater/EmailService.java
+++ b/src/main/java/kori/tour/email/application/updater/EmailService.java
@@ -8,12 +8,15 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kori.tour.email.adapter.out.persistence.EmailContentRepository;
 import kori.tour.email.adapter.out.persistence.EmailRepository;
+import kori.tour.email.application.updater.client.EmailClient;
+import kori.tour.email.application.updater.client.EmailSendResponse;
 import kori.tour.email.application.updater.dto.EmailSendRequest;
 import kori.tour.email.domain.Email;
+import kori.tour.email.domain.EmailContent;
 import kori.tour.member.adapter.out.persistence.MemberRepository;
 import kori.tour.member.domain.Member;
-import kori.tour.member.domain.PlatformInfo;
 import kori.tour.tour.adapter.out.persistence.TourRepository;
 import kori.tour.tour.domain.Tour;
 import lombok.RequiredArgsConstructor;
@@ -24,41 +27,45 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class EmailService {
 
-	private final EmailSendUseCase emailSendUseCase;
+	private final EmailClient emailClient;
 	private final EmailRepository emailRepository;
 	private final TourRepository tourRepository;
 	private final MemberRepository memberRepository;
+	private final EmailContentRepository emailContentRepository;
 
 
 	public Slice<Member> findMembersBySubscription(String areaCode, String sigunGucCode, Pageable pageRequest){
 		return memberRepository.findBySubscriptionArea(areaCode, sigunGucCode, pageRequest);
 	}
 
-	public String sendEmailToMembers(EmailSendRequest requestDto) {
-		List<String> emails = requestDto.members().stream()
-				.map(Member::getPlatformInfo)
-				.map(PlatformInfo::getPlatformEmail)
-				.toList();
+	public EmailSendResponse sendEmailToMembers(EmailSendRequest requestDto) {
+		EmailSendResponse emailSendResponse = emailClient.sendEmail(requestDto.emails(), requestDto.emailTitle(), requestDto.emailContent());
+		log.info("Email sent to {} with messageId {}", requestDto.emails(), emailSendResponse.messageId());
 
-		String messageId = emailSendUseCase.sendEmail(emails, requestDto.emailTitle(), requestDto.emailContent());
-		log.info("Email sent to {} with messageId {}", emails, messageId);
-
-		return messageId;
+		return emailSendResponse;
 	}
 
 	@Transactional
-	public void saveEmails(List<Member> members, String messageId, Tour tour, String emailTitle, String emailBody) {
-		LocalDateTime sendTime = LocalDateTime.now();
+	public void saveEmails(List<Member> members, EmailSendResponse emailSendResponse, Tour tour, String emailTitle, String minifiedEmailBody) {
+		String messageId = emailSendResponse.messageId();
+		LocalDateTime sendTime = emailSendResponse.sendTime();
+
+		EmailContent emailContent = EmailContent.builder()
+				.title(emailTitle)
+				.body(minifiedEmailBody)
+				.messageId(messageId)
+				.build();
+
 		Tour savedTour = tourRepository.save(tour);
+		EmailContent savedEmailContent = emailContentRepository.save(emailContent);
 		List<Member> savedMembers = memberRepository.saveAll(members);
+
 		for (Member member : savedMembers) {
 			Email email = Email.builder()
 					.member(member)
 					.tour(savedTour)
 					.sendTime(sendTime)
-					.title(emailTitle)
-					.body(emailBody)
-					.messageId(messageId)
+					.emailContent(savedEmailContent)
 					.build();
 			emailRepository.save(email);
 		}

--- a/src/main/java/kori/tour/email/application/updater/client/EmailClient.java
+++ b/src/main/java/kori/tour/email/application/updater/client/EmailClient.java
@@ -1,0 +1,8 @@
+package kori.tour.email.application.updater.client;
+
+import java.util.List;
+
+public interface EmailClient {
+
+    EmailSendResponse sendEmail(List<String> recipients, String title, String content);
+}

--- a/src/main/java/kori/tour/email/application/updater/client/EmailSendResponse.java
+++ b/src/main/java/kori/tour/email/application/updater/client/EmailSendResponse.java
@@ -1,0 +1,7 @@
+package kori.tour.email.application.updater.client;
+
+import java.time.LocalDateTime;
+
+public record EmailSendResponse (String messageId, LocalDateTime sendTime){
+
+}

--- a/src/main/java/kori/tour/email/application/updater/client/SmtpEmailClient.java
+++ b/src/main/java/kori/tour/email/application/updater/client/SmtpEmailClient.java
@@ -1,5 +1,7 @@
-package kori.tour.email.application.updater;
+package kori.tour.email.application.updater.client;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
@@ -12,7 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
-public class EmailSendService implements EmailSendUseCase{
+class SmtpEmailClient implements EmailClient {
 
     @Value("${email.host}")
     private String smtpHost;
@@ -25,7 +27,7 @@ public class EmailSendService implements EmailSendUseCase{
 
 
     @Override
-    public String sendEmail(List<String> recipients, String title, String content) {
+    public EmailSendResponse sendEmail(List<String> recipients, String title, String content) {
         Session session = getSessionWithSmtpServer();
 
         for (String recipient :  recipients) {
@@ -43,7 +45,8 @@ public class EmailSendService implements EmailSendUseCase{
                 throw new RuntimeException("Msg error occurred while sending an email ",e);
             }
         }
-        return UUID.randomUUID().toString();
+        // 모든 이메일은 동시에 보내졌다고 가정한다
+        return new EmailSendResponse(UUID.randomUUID().toString(), LocalDateTime.now(ZoneId.of("Asia/Seoul")));
     }
 
     private Session getSessionWithSmtpServer() {

--- a/src/main/java/kori/tour/email/application/updater/dto/EmailSendRequest.java
+++ b/src/main/java/kori/tour/email/application/updater/dto/EmailSendRequest.java
@@ -2,10 +2,9 @@ package kori.tour.email.application.updater.dto;
 
 import java.util.List;
 
-import kori.tour.member.domain.Member;
 
 public record EmailSendRequest(
-        List<Member> members,
+        List<String> emails,
         String emailTitle,
         String emailContent,
         String tourId,

--- a/src/main/java/kori/tour/email/domain/Email.java
+++ b/src/main/java/kori/tour/email/domain/Email.java
@@ -27,13 +27,11 @@ public class Email {
 	@ManyToOne(fetch = FetchType.LAZY)
 	private Tour tour;
 
+	// 이메일이 실제로 보내진 시간과 오차가 있을 수 있음
 	private LocalDateTime sendTime;
 
-	private String title;
-
-	private String body;
-
-	@Column(name = "ses_message_id", unique = false)
-	private String messageId;
+	@JoinColumn(name = "email_content_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private EmailContent emailContent;
 
 }

--- a/src/main/java/kori/tour/email/domain/EmailContent.java
+++ b/src/main/java/kori/tour/email/domain/EmailContent.java
@@ -20,7 +20,7 @@ public class EmailContent {
     @Column(columnDefinition = "MEDIUMTEXT")
     private String body;
 
-    @Column(name = "ses_message_id", length = 36)
+    @Column(name = "ses_message_id", length = 36, unique = true)
     private String messageId;
 
 }

--- a/src/main/java/kori/tour/email/domain/EmailContent.java
+++ b/src/main/java/kori/tour/email/domain/EmailContent.java
@@ -1,0 +1,26 @@
+package kori.tour.email.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class EmailContent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "email_content_id")
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "MEDIUMTEXT")
+    private String body;
+
+    @Column(name = "ses_message_id", unique = false)
+    private String messageId;
+
+}

--- a/src/main/java/kori/tour/email/domain/EmailContent.java
+++ b/src/main/java/kori/tour/email/domain/EmailContent.java
@@ -20,7 +20,7 @@ public class EmailContent {
     @Column(columnDefinition = "MEDIUMTEXT")
     private String body;
 
-    @Column(name = "ses_message_id", unique = false)
+    @Column(name = "ses_message_id", length = 36)
     private String messageId;
 
 }

--- a/src/main/resources/db/migration/V1__Base_line.sql
+++ b/src/main/resources/db/migration/V1__Base_line.sql
@@ -72,10 +72,9 @@ CREATE TABLE tour_image (
                             small_image_url   VARCHAR(512),
                             image_name        VARCHAR(255),
                             serial_number     VARCHAR(100),
-                            CONSTRAINT fk_tour_image_tour FOREIGN KEY (tour_id)
-                                REFERENCES tour(tour_id)
-                                ON UPDATE CASCADE
-                                ON DELETE CASCADE
+                            CONSTRAINT fk_tour_image_tour
+                                FOREIGN KEY (tour_id) REFERENCES tour(tour_id)
+                                    ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_tour_image_tour ON tour_image (tour_id);
@@ -89,10 +88,9 @@ CREATE TABLE tour_repeat (
                              serial_number     VARCHAR(100),
                              info_name         VARCHAR(255),
                              info_text         TEXT,
-                             CONSTRAINT fk_tour_repeat_tour FOREIGN KEY (tour_id)
-                                 REFERENCES tour(tour_id)
-                                 ON UPDATE CASCADE
-                                 ON DELETE CASCADE
+                             CONSTRAINT fk_tour_repeat_tour
+                                 FOREIGN KEY (tour_id) REFERENCES tour(tour_id)
+                                     ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_tour_repeat_tour ON tour_repeat (tour_id);
@@ -104,10 +102,9 @@ CREATE TABLE tour_keywords (
                                tour_id   BIGINT        NOT NULL,
                                keyword   VARCHAR(255)  NOT NULL,
                                CONSTRAINT pk_tour_keywords PRIMARY KEY (tour_id, keyword),
-                               CONSTRAINT fk_tour_keywords_tour FOREIGN KEY (tour_id)
-                                   REFERENCES tour(tour_id)
-                                   ON UPDATE CASCADE
-                                   ON DELETE CASCADE
+                               CONSTRAINT fk_tour_keywords_tour
+                                   FOREIGN KEY (tour_id) REFERENCES tour(tour_id)
+                                       ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- =========================================================
@@ -142,8 +139,7 @@ CREATE TABLE member_subscription (
                                      CONSTRAINT pk_member_subscription PRIMARY KEY (member_id, area_code, sigun_gu_code),
                                      CONSTRAINT fk_member_subscription_member
                                          FOREIGN KEY (member_id) REFERENCES member(member_id)
-                                             ON UPDATE CASCADE
-                                             ON DELETE CASCADE
+                                             ON UPDATE CASCADE ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_region ON member_subscription (area_code, sigun_gu_code);
@@ -163,7 +159,6 @@ CREATE TABLE email (
                        CONSTRAINT fk_email_member
                            FOREIGN KEY (member_id) REFERENCES member(member_id)
                                ON UPDATE CASCADE ON DELETE SET NULL,
--- ============================ 이메일이 전송된 후에도 Tour가 업데이트 될 경우 DB 에서 삭제되었다가 추가 되기 때문에 set null로 변경
                        CONSTRAINT fk_email_tour
                            FOREIGN KEY (tour_id) REFERENCES tour(tour_id)
                                ON UPDATE CASCADE ON DELETE SET NULL

--- a/src/main/resources/db/migration/V1__Base_line.sql
+++ b/src/main/resources/db/migration/V1__Base_line.sql
@@ -72,9 +72,10 @@ CREATE TABLE tour_image (
                             small_image_url   VARCHAR(512),
                             image_name        VARCHAR(255),
                             serial_number     VARCHAR(100),
-                            CONSTRAINT fk_tour_image_tour
-                                FOREIGN KEY (tour_id) REFERENCES tour(tour_id)
-                                    ON UPDATE CASCADE ON DELETE CASCADE
+                            CONSTRAINT fk_tour_image_tour FOREIGN KEY (tour_id)
+                                REFERENCES tour(tour_id)
+                                ON UPDATE CASCADE
+                                ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_tour_image_tour ON tour_image (tour_id);
@@ -88,9 +89,10 @@ CREATE TABLE tour_repeat (
                              serial_number     VARCHAR(100),
                              info_name         VARCHAR(255),
                              info_text         TEXT,
-                             CONSTRAINT fk_tour_repeat_tour
-                                 FOREIGN KEY (tour_id) REFERENCES tour(tour_id)
-                                     ON UPDATE CASCADE ON DELETE CASCADE
+                             CONSTRAINT fk_tour_repeat_tour FOREIGN KEY (tour_id)
+                                 REFERENCES tour(tour_id)
+                                 ON UPDATE CASCADE
+                                 ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_tour_repeat_tour ON tour_repeat (tour_id);
@@ -102,9 +104,10 @@ CREATE TABLE tour_keywords (
                                tour_id   BIGINT        NOT NULL,
                                keyword   VARCHAR(255)  NOT NULL,
                                CONSTRAINT pk_tour_keywords PRIMARY KEY (tour_id, keyword),
-                               CONSTRAINT fk_tour_keywords_tour
-                                   FOREIGN KEY (tour_id) REFERENCES tour(tour_id)
-                                       ON UPDATE CASCADE ON DELETE CASCADE
+                               CONSTRAINT fk_tour_keywords_tour FOREIGN KEY (tour_id)
+                                   REFERENCES tour(tour_id)
+                                   ON UPDATE CASCADE
+                                   ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- =========================================================
@@ -139,7 +142,8 @@ CREATE TABLE member_subscription (
                                      CONSTRAINT pk_member_subscription PRIMARY KEY (member_id, area_code, sigun_gu_code),
                                      CONSTRAINT fk_member_subscription_member
                                          FOREIGN KEY (member_id) REFERENCES member(member_id)
-                                             ON UPDATE CASCADE ON DELETE CASCADE
+                                             ON UPDATE CASCADE
+                                             ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE INDEX idx_region ON member_subscription (area_code, sigun_gu_code);
@@ -159,6 +163,7 @@ CREATE TABLE email (
                        CONSTRAINT fk_email_member
                            FOREIGN KEY (member_id) REFERENCES member(member_id)
                                ON UPDATE CASCADE ON DELETE SET NULL,
+-- ============================ 이메일이 전송된 후에도 Tour가 업데이트 될 경우 DB 에서 삭제되었다가 추가 되기 때문에 set null로 변경
                        CONSTRAINT fk_email_tour
                            FOREIGN KEY (tour_id) REFERENCES tour(tour_id)
                                ON UPDATE CASCADE ON DELETE SET NULL

--- a/src/main/resources/db/migration/V3__Seperate_email_email_body.sql
+++ b/src/main/resources/db/migration/V3__Seperate_email_email_body.sql
@@ -1,0 +1,62 @@
+-- 기존 ON UPDATE CASCADE ON DELETE SET NULL 설정 제거
+ALTER TABLE email
+    DROP FOREIGN KEY fk_email_member;
+
+-- 기존 ON UPDATE CASCADE ON DELETE SET NULL 설정 제거
+ALTER TABLE email
+    ADD CONSTRAINT fk_email_member
+        FOREIGN KEY (member_id) REFERENCES member(member_id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE;
+
+-- =========== 실제 마이그레이션을 위한 SQL 구문 ========
+    -- 1. email_content 테이블 생성한다.
+    -- 2. email 테이블에서 title, body, ses_message_id 를 distinct 로 조회 후 email_content 에 저장
+            -- ( 현재 ses_message_id는 uuid로 유니크하지만 이 값은 여러 행에 중복으로 저장되어 있을 수 있다)
+    -- 3. email_content 테이블에 email_content_id 칼럼을 추가한다 ( 외래키 ) 그리고 ses_message_id를 이용해서 알맞은 email_content_id를 업데이트한다
+    -- 4. 연결이 잘 되었다면, email 테이블에서 title, body, ses_message_id 를 모두 제거한다.
+
+-- 1)
+-- CREATE TABLE email_content (
+--                                email_content_id    BIGINT AUTO_INCREMENT PRIMARY KEY,
+--                                title   VARCHAR(255),
+--                                body    MEDIUMTEXT,
+--                                ses_message_id  VARCHAR(36),
+--                                CONSTRAINT uk_email_content_message_id UNIQUE (ses_message_id)
+-- ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 2)
+-- INSERT INTO email_content (title, body, ses_message_id)
+-- SELECT
+--     distinct
+--     e.title,
+--     e.body,
+--     e.ses_message_id
+-- FROM email e
+-- GROUP BY e.ses_message_id;
+
+-- 3)
+-- ALTER TABLE email
+--     ADD COLUMN email_content_id BIGINT NULL AFTER send_time;
+-- CREATE INDEX idx_email_email_content ON email (email_content_id);
+--
+-- UPDATE email e
+--     JOIN email_content ec
+-- ON ec.ses_message_id = e.ses_message_id
+--     SET e.email_content_id = ec.email_content_id
+-- WHERE e.email_content_id IS NULL;
+--
+-- ALTER TABLE email
+--     ADD CONSTRAINT fk_email_content
+--         FOREIGN KEY (email_content_id) REFERENCES email_content(email_content_id)
+--             ON UPDATE CASCADE
+--             ON DELETE CASCADE;
+--
+-- ALTER TABLE email
+--     MODIFY email_content_id BIGINT NOT NULL;
+
+-- 4)
+-- ALTER TABLE email
+-- DROP COLUMN title,
+--   DROP COLUMN body,
+--   DROP COLUMN ses_message_id;

--- a/src/main/resources/db/migration/V4__emai_content_message_id_unique.sql
+++ b/src/main/resources/db/migration/V4__emai_content_message_id_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE email_content
+    ADD CONSTRAINT uk_email_content_ses_message_id UNIQUE (ses_message_id);

--- a/src/main/resources/templates/email-body.html
+++ b/src/main/resources/templates/email-body.html
@@ -7,10 +7,10 @@
     <div style="margin-bottom: 20px;">
         <h3 style="color: #444;">행사 개요</h3>
         <ul style="list-style: none; padding: 0; color: #555;">
-            <li><strong>진행 기간:</strong> <span th:text="${eventStartDate} + ' ~ ' + ${eventEndDate}"></span></li>
-            <li><strong>운영 시간:</strong> <span th:text="${playTime}"></span></li>
-            <li><strong>예상 소요시간:</strong> <span th:text="${spendTimeFestival}"></span></li>
-            <li><strong>비용:</strong> <span th:text="${useTimeFestival}"></span></li>
+            <li><strong>진행 기간:</strong> <span th:utext="${eventStartDate} + ' ~ ' + ${eventEndDate}"></span></li>
+            <li><strong>운영 시간:</strong> <span th:utext="${playTime}"></span></li>
+            <li><strong>예상 소요시간:</strong> <span th:utext="${spendTimeFestival}"></span></li>
+            <li><strong>비용:</strong> <span th:utext="${useTimeFestival}"></span></li>
             <li><strong>행사 키워드:</strong>
                 <span th:each="keyword : ${keywords}" th:text="|${keyword}|"></span>
             </li>
@@ -21,8 +21,8 @@
         <h3 style="color: #444;">행사 상세 정보</h3>
         <ul style="list-style: none; padding: 0; color: #555;">
             <li th:each="info : ${infoList}">
-                <strong th:text="${info.infoName}">정보 이름</strong>:
-                <span th:text="${info.infoText}">정보 내용</span>
+                <strong th:utext="${info.infoName}">정보 이름</strong>:
+                <span th:utext="${info.infoText}">정보 내용</span>
             </li>
         </ul>
     </div>
@@ -30,13 +30,13 @@
     <div style="margin-bottom: 20px;">
         <h3 style="color: #444;">오시는 길</h3>
         <ul style="list-style: none; padding: 0; color: #555;">
-            <li><strong>주소:</strong> <span th:text="${roadAddress}"></span></li>
-            <li><strong>세부 장소:</strong> <span th:text="${eventPlace}"></span></li>
-            <li><strong>연락처:</strong> <span th:text="${telephone}"></span></li>
+            <li><strong>주소:</strong> <span th:utext="${roadAddress}"></span></li>
+            <li><strong>세부 장소:</strong> <span th:utext="${eventPlace}"></span></li>
+            <li><strong>연락처:</strong> <span th:utext="${telephone}"></span></li>
         </ul>
     </div>
 
     <hr style="margin: 30px 0;" />
-    <p style="font-size: 0.9em; color: #999;">본 메일은 발신 전용입니다. 문의는 홈페이지를 이용해주세요.</p>
+    <p style="font-size: 0.9em; color: #999;">본 메일은 발신 전용입니다.</p>
 </div>
 </body>

--- a/src/test/java/kori/tour/tour/application/updater/TourApiClientTest.java
+++ b/src/test/java/kori/tour/tour/application/updater/TourApiClientTest.java
@@ -62,9 +62,7 @@ class TourApiClientTest {
                 .andRespond(withSuccess(metaDataResponse, MediaType.APPLICATION_JSON));
 
         // 페이지 1 (numOfRows=50, pageNo=1, eventStartDate=startDate)
-        String pageOneResponse = "{ \"response\": { \"body\": { \"items\": " +
-                "{ \"item\": [ { \"contentid\":\"1001\",\"title\":\"축제A\",\"contenttypeid\":\"15\" }, " +
-                "{ \"contentid\":\"1002\",\"title\":\"축제B\",\"contenttypeid\":\"15\" } ] } } } }";
+        String pageOneResponse = "{ \"response\": { \"body\": { \"items\": { \"item\": [ { \"contentid\":\"1001\",\"title\":\"축제A\",\"contenttypeid\":\"15\",\"eventenddate\":\"23001031\" }, { \"contentid\":\"1002\",\"title\":\"축제B\",\"contenttypeid\":\"15\",\"eventenddate\":\"23001031\" } ] } } } }";
 
         server.expect(times(1), requestTo(containsString("/searchFestival2")))
                 .andExpect(method(HttpMethod.GET))
@@ -74,8 +72,7 @@ class TourApiClientTest {
                 .andRespond(withSuccess(pageOneResponse, MediaType.APPLICATION_JSON));
 
         // 페이지 2
-        String pageTwoResponse = "{ \"response\": { \"body\": { \"items\": " +
-                "{ \"item\": [ { \"contentid\":\"1003\",\"title\":\"축제C\",\"contenttypeid\":\"15\" } ] } } } }";
+        String pageTwoResponse = "{ \"response\": { \"body\": { \"items\": { \"item\": [ { \"contentid\":\"1003\",\"title\":\"축제C\",\"contenttypeid\":\"15\",\"eventenddate\":\"23001031\" } ] } } } }";
 
         server.expect(times(1), requestTo(containsString("/searchFestival2")))
                 .andExpect(method(HttpMethod.GET))


### PR DESCRIPTION
## 📌 관련 이슈
close #22 
## ✨ 작업 내용
-HTML minify 로직 적용 문자열 저장량 약 10퍼 감소
- email 테이블의 title, body, ses_message_id를 별도의 email_content 테이블로 분리하여 중복저장 감소
- Flyway 마이그레이션 코드 적용

## 📚 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Emails now render rich HTML for event details and information lists.
  - Email HTML is minified to reduce size and improve delivery.

- Refactor
  - Email sending and content handling centralized so messages are stored and delivered more consistently.

- Style
  - Updated email footer text to: “본 메일은 발신 전용입니다.”

- Chores
  - Added an HTML parsing library and database migrations to support content storage changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->