### PR TITLE
LLM API - retry 주기 변경

### DIFF
--- a/src/main/java/kori/tour/config/cache/CacheConfig.java
+++ b/src/main/java/kori/tour/config/cache/CacheConfig.java
@@ -9,13 +9,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
-import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.cache.RedisCacheManager;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.cache.Cache;
 
 @Configuration
 @EnableCaching

--- a/src/main/java/kori/tour/config/cache/TwoLevelCache.java
+++ b/src/main/java/kori/tour/config/cache/TwoLevelCache.java
@@ -1,11 +1,12 @@
 package kori.tour.config.cache;
 
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.Callable;
+
 import org.springframework.cache.Cache;
 import org.springframework.cache.support.SimpleValueWrapper;
 import org.springframework.lang.Nullable;
 
-import java.util.concurrent.Callable;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class TwoLevelCache implements Cache {

--- a/src/main/java/kori/tour/global/exception/code/ErrorCode.java
+++ b/src/main/java/kori/tour/global/exception/code/ErrorCode.java
@@ -26,8 +26,10 @@ public enum ErrorCode {
 
 
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
-	TOUR_NOT_FOUND(HttpStatus.NOT_FOUND, "투어를 찾을 수 없습니다.");
+	TOUR_NOT_FOUND(HttpStatus.NOT_FOUND, "투어를 찾을 수 없습니다."),
 
+	AI_RESPONSE_WRONG_FORMAT(null,"프롬프트에 명시한 형식대로 응답이 오지 않았습니다."),
+	AI_RESPONSE_RATE_LIMIT(null,"LLM API의 RATE LIMIT에 도달했습니다.");
 
 	private final HttpStatus httpStatus;
 

--- a/src/main/java/kori/tour/keyword/application/updater/KeywordExtractService.java
+++ b/src/main/java/kori/tour/keyword/application/updater/KeywordExtractService.java
@@ -59,7 +59,7 @@ public class KeywordExtractService {
 
 	@Recover
 	public List<String> recoverFromAiFailure(AiApiException e, FestivalDocument festivalDocument) {
-		log.error("AI 키워드 추출 실패 - 모든 재시도 시도 후에도 응답 없음. festivalDocument={}, message={}",
+		log.warn("AI 키워드 추출 실패 - 3회 재시도 후에도 적절하게 처리되지 않았음. festivalDocument={}, message={}",
 				FestivalDocument.toJson(festivalDocument), e.getMessage(), e);
 		return new ArrayList<>(); // 일단 정상흐름으로
 	}

--- a/src/main/java/kori/tour/keyword/application/updater/KeywordExtractService.java
+++ b/src/main/java/kori/tour/keyword/application/updater/KeywordExtractService.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import kori.tour.global.exception.code.ErrorCode;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.evaluation.EvaluationRequest;
 import org.springframework.ai.evaluation.EvaluationResponse;
@@ -14,6 +13,7 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import kori.tour.global.exception.code.ErrorCode;
 import kori.tour.keyword.application.port.out.KeywordExtractingPort;
 import kori.tour.keyword.application.updater.parser.AiApiException;
 import kori.tour.keyword.application.updater.parser.AiModelResponseParser;

--- a/src/main/java/kori/tour/keyword/application/updater/parser/AiApiException.java
+++ b/src/main/java/kori/tour/keyword/application/updater/parser/AiApiException.java
@@ -1,9 +1,15 @@
 package kori.tour.keyword.application.updater.parser;
 
+import kori.tour.global.exception.code.ErrorCode;
+
 public class AiApiException extends RuntimeException {
 
-	public AiApiException(String message, Throwable cause) {
-		super(message, cause);
+	public AiApiException(ErrorCode errorCode, Throwable cause) {
+		super(errorCode.getMessage(), cause);
+	}
+
+	public AiApiException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
 	}
 
 }

--- a/src/main/java/kori/tour/keyword/application/updater/parser/AiModelResponseParser.java
+++ b/src/main/java/kori/tour/keyword/application/updater/parser/AiModelResponseParser.java
@@ -3,6 +3,7 @@ package kori.tour.keyword.application.updater.parser;
 import java.util.ArrayList;
 import java.util.List;
 
+import kori.tour.global.exception.code.ErrorCode;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -16,8 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 public class AiModelResponseParser {
 
 	private final ObjectMapper mapper = new ObjectMapper();
-
-	private final String AI_API_ERROR_MESSAGE = "지정한 형식대로 응답이 오지 않음";
 
 	public List<String> mapToKeywords(String jsonResponse) {
 		List<String> keywords = new ArrayList<>();
@@ -34,7 +33,7 @@ public class AiModelResponseParser {
 		}
 		catch (JsonProcessingException e) {
 			log.warn("AI 키워드 응답 파싱중 에러 발생 response = {}", jsonResponse, e);
-			throw new AiApiException(AI_API_ERROR_MESSAGE, e);
+			throw new AiApiException(ErrorCode.AI_RESPONSE_WRONG_FORMAT, e);
 		}
 
 		return keywords;

--- a/src/main/java/kori/tour/keyword/application/updater/parser/AiModelResponseParser.java
+++ b/src/main/java/kori/tour/keyword/application/updater/parser/AiModelResponseParser.java
@@ -3,13 +3,13 @@ package kori.tour.keyword.application.updater.parser;
 import java.util.ArrayList;
 import java.util.List;
 
-import kori.tour.global.exception.code.ErrorCode;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import kori.tour.global.exception.code.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/src/main/resources/db/migration/V3__Seperate_email_email_body.sql
+++ b/src/main/resources/db/migration/V3__Seperate_email_email_body.sql
@@ -10,53 +10,53 @@ ALTER TABLE email
             ON DELETE CASCADE;
 
 -- =========== 실제 마이그레이션을 위한 SQL 구문 ========
-    -- 1. email_content 테이블 생성한다.
-    -- 2. email 테이블에서 title, body, ses_message_id 를 distinct 로 조회 후 email_content 에 저장
-            -- ( 현재 ses_message_id는 uuid로 유니크하지만 이 값은 여러 행에 중복으로 저장되어 있을 수 있다)
-    -- 3. email_content 테이블에 email_content_id 칼럼을 추가한다 ( 외래키 ) 그리고 ses_message_id를 이용해서 알맞은 email_content_id를 업데이트한다
-    -- 4. 연결이 잘 되었다면, email 테이블에서 title, body, ses_message_id 를 모두 제거한다.
+--     1. email_content 테이블 생성한다.
+--     2. email 테이블에서 title, body, ses_message_id 를 distinct 로 조회 후 email_content 에 저장
+--             ( 현재 ses_message_id는 uuid로 유니크하지만 이 값은 여러 행에 중복으로 저장되어 있을 수 있다)
+--     3. email_content 테이블에 email_content_id 칼럼을 추가한다 ( 외래키 ) 그리고 ses_message_id를 이용해서 알맞은 email_content_id를 업데이트한다
+--     4. 연결이 잘 되었다면, email 테이블에서 title, body, ses_message_id 를 모두 제거한다.
 
 -- 1)
--- CREATE TABLE email_content (
---                                email_content_id    BIGINT AUTO_INCREMENT PRIMARY KEY,
---                                title   VARCHAR(255),
---                                body    MEDIUMTEXT,
---                                ses_message_id  VARCHAR(36),
---                                CONSTRAINT uk_email_content_message_id UNIQUE (ses_message_id)
--- ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+CREATE TABLE email_content (
+                               email_content_id    BIGINT AUTO_INCREMENT PRIMARY KEY,
+                               title   VARCHAR(255),
+                               body    MEDIUMTEXT,
+                               ses_message_id  VARCHAR(36),
+                               CONSTRAINT uk_email_content_message_id UNIQUE (ses_message_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 2)
--- INSERT INTO email_content (title, body, ses_message_id)
--- SELECT
---     distinct
---     e.title,
---     e.body,
---     e.ses_message_id
--- FROM email e
--- GROUP BY e.ses_message_id;
+INSERT INTO email_content (title, body, ses_message_id)
+SELECT
+    distinct
+    e.title,
+    e.body,
+    e.ses_message_id
+FROM email e
+GROUP BY e.ses_message_id;
 
 -- 3)
--- ALTER TABLE email
---     ADD COLUMN email_content_id BIGINT NULL AFTER send_time;
--- CREATE INDEX idx_email_email_content ON email (email_content_id);
---
--- UPDATE email e
---     JOIN email_content ec
--- ON ec.ses_message_id = e.ses_message_id
---     SET e.email_content_id = ec.email_content_id
--- WHERE e.email_content_id IS NULL;
---
--- ALTER TABLE email
---     ADD CONSTRAINT fk_email_content
---         FOREIGN KEY (email_content_id) REFERENCES email_content(email_content_id)
---             ON UPDATE CASCADE
---             ON DELETE CASCADE;
---
--- ALTER TABLE email
---     MODIFY email_content_id BIGINT NOT NULL;
+ALTER TABLE email
+    ADD COLUMN email_content_id BIGINT NULL AFTER send_time;
+CREATE INDEX idx_email_email_content ON email (email_content_id);
+
+UPDATE email e
+    JOIN email_content ec
+ON ec.ses_message_id = e.ses_message_id
+    SET e.email_content_id = ec.email_content_id
+WHERE e.email_content_id IS NULL;
+
+ALTER TABLE email
+    ADD CONSTRAINT fk_email_content
+        FOREIGN KEY (email_content_id) REFERENCES email_content(email_content_id)
+            ON UPDATE CASCADE
+            ON DELETE CASCADE;
+
+ALTER TABLE email
+    MODIFY email_content_id BIGINT NOT NULL;
 
 -- 4)
--- ALTER TABLE email
--- DROP COLUMN title,
---   DROP COLUMN body,
---   DROP COLUMN ses_message_id;
+ALTER TABLE email
+DROP COLUMN title,
+  DROP COLUMN body,
+  DROP COLUMN ses_message_id;

--- a/src/test/java/kori/tour/keyword/application/updater/KeywordExtractServiceTest.java
+++ b/src/test/java/kori/tour/keyword/application/updater/KeywordExtractServiceTest.java
@@ -1,100 +1,201 @@
 package kori.tour.keyword.application.updater;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.evaluation.EvaluationRequest;
 import org.springframework.ai.evaluation.EvaluationResponse;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.retry.backoff.Sleeper;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import kori.tour.keyword.application.port.out.KeywordExtractingPort;
-import kori.tour.keyword.application.updater.parser.AiApiException;
+import kori.tour.keyword.application.updater.parser.AiModelResponseParser;
 import kori.tour.keyword.application.updater.parser.FestivalDocument;
+import kori.tour.keyword.application.updater.parser.AiApiException;
+import kori.tour.global.exception.code.ErrorCode;
 
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = KeywordExtractServiceTest.TestConfig.class)
 class KeywordExtractServiceTest {
 
-	@MockBean
-    TourKeywordAiModelClient tourKeywordAiModelClient;
-
-	@MockBean
-	KeywordExtractingPort keywordExtractingPort;
-
-	@MockBean
-	KeywordEvaluator keywordEvaluator;
+	@Autowired
+	private KeywordExtractService keywordExtractService;
 
 	@Autowired
-	KeywordExtractService keywordExtractService;
+	private TourKeywordAiModelClient tourKeywordAiModelClient;
 
-	@Test
-	@DisplayName("키워드 추출: 정상 응답")
-	void extractKeywords() throws AiApiException {
-		// given
-		FestivalDocument festivalDocument = getFestivalDocument();
-		doReturn(getKeywordResponse()).when(tourKeywordAiModelClient).call(any());
-		doReturn(new EvaluationResponse(true,0,null,null)).when(keywordEvaluator).evaluate(any());
+	@Autowired
+	private AiModelResponseParser aiModelResponseParser;
 
-		// when
-		List<String> keywords = keywordExtractService.extractKeywords(festivalDocument);
+	@Autowired
+	private PromptBuilder promptBuilder;
 
-		// then
-		assertEquals(3, keywords.size());
-		assertTrue(keywords.contains("keyword1"));
-		assertTrue(keywords.contains("keyword2"));
-		assertTrue(keywords.contains("keyword3"));
+	@Autowired
+	private KeywordEvaluator keywordEvaluator;
+
+	@Autowired
+	private KeywordExtractingPort keywordExtractingPort;
+
+	private FestivalDocument festivalDocument;
+
+	@BeforeEach
+	void setUp() {
+		Mockito.reset(tourKeywordAiModelClient, aiModelResponseParser, promptBuilder, keywordEvaluator,
+			keywordExtractingPort);
+
+		festivalDocument = FestivalDocument.builder()
+			.festivalName("2025 봄꽃 페스티벌")
+			.festivalDetails(Map.of("행사일정", "2025년 4월 10일 ~ 4월 12일"))
+			.build();
 	}
 
 	@Test
-	@DisplayName("키워드 추출: 빈 Json")
-	void extractKeywords_empty() throws AiApiException {
+	@DisplayName("키워드 추출 서비스: 정상 응답")
+	void givenValidAiResponse_whenExtractKeywords_thenReturnKeywords() {
 		// given
-		FestivalDocument festivalDocument = getFestivalDocument();
-		doReturn("{}").when(tourKeywordAiModelClient).call(any());
-		doReturn(new EvaluationResponse(true,0,null,null)).when(keywordEvaluator).evaluate(any());
+		Prompt prompt = new Prompt("문서에서 키워드를 추출");
+		String aiResponse = "{\"keywords\": [\"keyword1\", \"keyword2\"]}";
+		List<String> parsedKeywords = List.of("keyword1", "keyword2");
+		given(promptBuilder.buildKeywordPrompt(anyString())).willReturn(prompt);
+		given(tourKeywordAiModelClient.call(prompt)).willReturn(aiResponse);
+		given(aiModelResponseParser.mapToKeywords(aiResponse)).willReturn(parsedKeywords);
+		given(keywordEvaluator.evaluate(any(EvaluationRequest.class))).willReturn(new EvaluationResponse(true, 0, null, null));
 
 		// when
-		List<String> keywords = keywordExtractService.extractKeywords(festivalDocument);
+		List<String> result = keywordExtractService.extractKeywords(festivalDocument);
 
 		// then
-		assertTrue(keywords.isEmpty());
+		assertThat(result).containsExactlyElementsOf(parsedKeywords);
+		then(tourKeywordAiModelClient).should().call(prompt);
+		then(keywordEvaluator).should().evaluate(any(EvaluationRequest.class));
 	}
 
 	@Test
-	@DisplayName("키워드 추출 실패 : 지정한 형식이 아닌 응답")
-	void extractKeywords_invalidJson_throwsException() {
+	@DisplayName("키워드 추출 서비스: 키워드 평가 실패 시 모든 재시도 후, 빈 키워드 리스트 반환")
+	void givenEvaluationAlwaysFails_whenExtractKeywords_thenReturnEmptyList() {
 		// given
-		FestivalDocument festivalDocument = getFestivalDocument();
-		doReturn("wrong answer").when(tourKeywordAiModelClient).call(any());
-		doReturn(new EvaluationResponse(true,0,null,null)).when(keywordEvaluator).evaluate(any());
+		Prompt prompt = new Prompt("문서에서 키워드를 추출");
+		String aiResponse = "{\"keywords\": [\"keyword1\"]}";
+		List<String> parsedKeywords = List.of("keyword1");
+		given(promptBuilder.buildKeywordPrompt(anyString())).willReturn(prompt);
+		given(tourKeywordAiModelClient.call(prompt)).willReturn(aiResponse);
+		given(aiModelResponseParser.mapToKeywords(aiResponse)).willReturn(parsedKeywords);
+		given(keywordEvaluator.evaluate(any(EvaluationRequest.class))).willReturn(new EvaluationResponse(false, 0, null, null));
 
 		// when
-		ThrowableAssert.ThrowingCallable callable = () -> keywordExtractService.extractKeywords(festivalDocument);
+		List<String> result = keywordExtractService.extractKeywords(festivalDocument);
 
 		// then
-		assertThatThrownBy(callable).isInstanceOf(AiApiException.class);
+		assertThat(result).isEmpty();
+		then(keywordEvaluator).should(times(3)).evaluate(any(EvaluationRequest.class));
+		then(tourKeywordAiModelClient).should(times(3)).call(prompt);
 	}
 
-	private String getKeywordResponse() {
-		return "{\"keywords\": [\"keyword1\", \"keyword2\", \"keyword3\"]}";
+	@Test
+	@DisplayName("키워드 추출 서비스: AiApiException 발생 -> 재시도 후 성공")
+	void givenParserThrowsTwice_whenExtractKeywords_thenRetryAndSucceed() {
+		// given
+		Prompt prompt = new Prompt("문서에서 키워드를 추출");
+		String aiResponse = "{\"keywords\": [\"keyword1\", \"keyword2\"]}";
+		List<String> parsedKeywords = List.of("keyword1", "keyword2");
+		given(promptBuilder.buildKeywordPrompt(anyString())).willReturn(prompt);
+		given(tourKeywordAiModelClient.call(prompt)).willReturn(aiResponse);
+		given(aiModelResponseParser.mapToKeywords(aiResponse))
+			.willThrow(new AiApiException(ErrorCode.AI_RESPONSE_WRONG_FORMAT))
+			.willThrow(new AiApiException(ErrorCode.AI_RESPONSE_WRONG_FORMAT))
+			.willReturn(parsedKeywords);
+		given(keywordEvaluator.evaluate(any(EvaluationRequest.class))).willReturn(new EvaluationResponse(true, 0, null, null));
+
+		// when
+		List<String> result = keywordExtractService.extractKeywords(festivalDocument);
+
+		// then
+		assertThat(result).containsExactlyElementsOf(parsedKeywords);
+		then(tourKeywordAiModelClient).should(times(3)).call(prompt);
+		then(aiModelResponseParser).should(times(3)).mapToKeywords(aiResponse);
 	}
 
-	private FestivalDocument getFestivalDocument() {
-		Map<String, String> festivalDetails = new HashMap<>();
-		festivalDetails.put("행사일정", "2025년 4월 10일 ~ 4월 12일");
-		festivalDetails.put("주최", "서울특별시");
+	@Test
+	@DisplayName("키워드 추출 서비스: 최대 재시도 실패 시 복구 로직 실행")
+	void givenParserAlwaysFails_whenExtractKeywords_thenRecoverWithEmptyList() {
+		// given
+		Prompt prompt = new Prompt("문서에서 키워드를 추출");
+		String aiResponse = "{\"keywords\": []}";
+		given(promptBuilder.buildKeywordPrompt(anyString())).willReturn(prompt);
+		given(tourKeywordAiModelClient.call(prompt)).willReturn(aiResponse);
+		given(aiModelResponseParser.mapToKeywords(aiResponse)).willThrow(new AiApiException(ErrorCode.AI_RESPONSE_WRONG_FORMAT));
 
-		return FestivalDocument.builder().festivalName("2025 봄꽃 페스티벌").festivalDetails(festivalDetails).build();
+		// when
+		List<String> result = keywordExtractService.extractKeywords(festivalDocument);
+
+		// then
+		assertThat(result).isEmpty();
+		then(aiModelResponseParser).should(times(3)).mapToKeywords(aiResponse);
+	}
+
+	@TestConfiguration
+	@EnableRetry
+	static class TestConfig {
+
+		@Bean
+		KeywordExtractService keywordExtractService(
+			TourKeywordAiModelClient tourKeywordAiModelClient,
+			AiModelResponseParser aiModelResponseParser,
+			PromptBuilder promptBuilder,
+			KeywordExtractingPort keywordExtractingPort,
+			KeywordEvaluator keywordEvaluator
+		) {
+			return new KeywordExtractService(tourKeywordAiModelClient, aiModelResponseParser, promptBuilder,
+				keywordExtractingPort, keywordEvaluator);
+		}
+
+		@Bean
+		TourKeywordAiModelClient tourKeywordAiModelClient() {
+			return Mockito.mock(TourKeywordAiModelClient.class);
+		}
+
+		@Bean
+		AiModelResponseParser aiModelResponseParser() {
+			return Mockito.mock(AiModelResponseParser.class);
+		}
+
+		@Bean
+		PromptBuilder promptBuilder() {
+			return Mockito.mock(PromptBuilder.class);
+		}
+
+		@Bean
+		KeywordEvaluator keywordEvaluator() {
+			return Mockito.mock(KeywordEvaluator.class);
+		}
+
+		@Bean
+		KeywordExtractingPort keywordExtractingPort() {
+			return Mockito.mock(KeywordExtractingPort.class);
+		}
+
+		@Bean
+		Sleeper noDelaySleeper() { // @EnableRetry 어노테이션 내부 Sleeper에 주입되는 빈
+			return backOffPeriod -> { }; // delay 0 for test
+		}
 	}
 
 }

--- a/src/test/java/kori/tour/keyword/application/updater/KeywordExtractServiceTest.java
+++ b/src/test/java/kori/tour/keyword/application/updater/KeywordExtractServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
+
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.evaluation.EvaluationRequest;
 import org.springframework.ai.evaluation.EvaluationResponse;
@@ -26,11 +27,11 @@ import org.springframework.retry.backoff.Sleeper;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import kori.tour.global.exception.code.ErrorCode;
 import kori.tour.keyword.application.port.out.KeywordExtractingPort;
+import kori.tour.keyword.application.updater.parser.AiApiException;
 import kori.tour.keyword.application.updater.parser.AiModelResponseParser;
 import kori.tour.keyword.application.updater.parser.FestivalDocument;
-import kori.tour.keyword.application.updater.parser.AiApiException;
-import kori.tour.global.exception.code.ErrorCode;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = KeywordExtractServiceTest.TestConfig.class)

--- a/src/test/java/kori/tour/keyword/application/updater/parser/AiModelResponseParserTest.java
+++ b/src/test/java/kori/tour/keyword/application/updater/parser/AiModelResponseParserTest.java
@@ -1,0 +1,46 @@
+package kori.tour.keyword.application.updater.parser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import kori.tour.global.exception.code.ErrorCode;
+
+class AiModelResponseParserTest {
+
+	private final AiModelResponseParser parser = new AiModelResponseParser();
+
+	@Test
+	@DisplayName("키워드 추출: 정상 응답")
+	void givenKeywordsArray_whenMapToKeywords_thenReturnsSameList() {
+		String json = """
+			{
+			  "keywords": ["mountain", "lake", "festival"]
+			}
+			""";
+
+		// when
+		List<String> keywords = parser.mapToKeywords(json);
+
+		// then
+		assertThat(keywords).containsExactly("mountain", "lake", "festival");
+	}
+
+	@Test
+	@DisplayName("키워드 추출: 잘못된 JSON")
+	void givenMalformedJson_whenMapToKeywords_thenThrowsAiApiException() {
+		// when
+		AiApiException exception = assertThrows(AiApiException.class, () -> parser.mapToKeywords("{"));
+
+		// then
+		assertThat(exception).hasMessage(ErrorCode.AI_RESPONSE_WRONG_FORMAT.getMessage());
+		assertThat(exception.getCause()).isInstanceOf(JsonProcessingException.class);
+	}
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
#23 

## ✨ 작업 내용
- AI API Rate limit (1분) 을 고려하여 Retry 주기 1분으로 설정
- 테스트 케이스에 Retry 가 정상적으로 동작하는지 확인하는 케이스 추가

## 📚 기타
- Retry 가 실패하는 상황이 있다면, 추후에 주기를 늘려주자.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added specific error messages for AI response failures, including format validation and rate limit handling.

* **Bug Fixes**
  * Improved error handling and retry logic for AI-based operations.

* **Database**
  * Optimized email data storage structure by separating content from metadata.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->